### PR TITLE
Fix path with spaces problem

### DIFF
--- a/adb.py
+++ b/adb.py
@@ -18,11 +18,11 @@ class ADB(object):
         return [device for device in devices if len(device) > 2]
 
     def upload(self, fr, to):
-        result = self.call("push " + fr + " " + to)
+        result = self.call('push "' + fr + '" "' + to + '"')
         return result
     
     def get(self, fr, to):
-        result = self.call("pull " + fr + " " + to)
+        result = self.call('pull "' + fr + '" "' + to + '"')
         return result
 
     def install(self, param):


### PR DESCRIPTION
if the from/to path had spaces in it it wouldn't work. 
So I added quotes before and after the path. 